### PR TITLE
Add support for dashboard_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ among the cloudfoundry installation to register with (among orgs and spaces).
 as ```tag1,tag2,tag3```, default is ```[]```)
 * SERVICES[{SERVICE_ID}]_REQUIRES (String holding an array-of-strings, multiple requires are separated by comma,
 as ```syslog_drain, route_forwarding```, default is ```[]```). A list of permissions that the user would have to give the service, if they provision it. The only permission currently supported is syslog_drain.
+* SERVICES[{SERVICE_ID}]_DASHBOARD_URL (String, no default). The URL of a web-based management user interface for the service instance.
 * SERVICES[{SERVICE_ID}]_METADATA_DISPLAY_NAME (String, default is SERVICES_ID_NAME). The user-facing name of the service.
 * SERVICES[{SERVICE_ID}]_METADATA_IMAGE_URL (String, default is "")
 * SERVICES[{SERVICE_ID}]_METADATA_SUPPORT_URL (String, default is "")
@@ -130,6 +131,7 @@ Multiple plans are supported. Use the following environment variables to configu
 * SERVICES[{SERVICE_ID}]\_PLANS\[{PLAN_ID}]_DESCRIPTION (String, default is "Default plan")
 * SERVICES[{SERVICE_ID}]\_PLANS\[{PLAN_ID}]_METADATA (String holding a JSON object, default is "{}")
 * SERVICES[{SERVICE_ID}]\_PLANS\[{PLAN_ID}]_FREE (String, default is "true")
+* SERVICES[{SERVICE_ID}]\_PLANS\[{PLAN_ID}]_DASHBOARD_URL (String, no default). The URL of a web-based management user interface for the service instance.
 
 A number of catalog variables are not configureable, the broker always return the following default value:
 * requires: ```[]``` (empty array)

--- a/src/main/java/com/orange/servicebroker/staticcreds/domain/Plan.java
+++ b/src/main/java/com/orange/servicebroker/staticcreds/domain/Plan.java
@@ -52,6 +52,12 @@ public class Plan {
      */
     private String syslogDrainUrl;
 
+    /**
+     * The URL of a web-based management user interface for the service instance. Can be <code>null</code> to indicate
+     * that a management dashboard is not provided.
+     */
+    private String dashboardUrl;
+
     public Plan() {
     }
 

--- a/src/main/java/com/orange/servicebroker/staticcreds/domain/Service.java
+++ b/src/main/java/com/orange/servicebroker/staticcreds/domain/Service.java
@@ -1,12 +1,12 @@
 package com.orange.servicebroker.staticcreds.domain;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import lombok.*;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 import org.hibernate.validator.constraints.NotEmpty;
 import org.springframework.boot.json.JsonParser;
 import org.springframework.boot.json.JsonParserFactory;
-import org.springframework.cloud.servicebroker.model.EmptyListSerializer;
 import org.springframework.cloud.servicebroker.model.ServiceDefinitionRequires;
 
 import javax.validation.Valid;
@@ -64,6 +64,12 @@ public class Service {
      * {@link ServiceDefinitionRequires} for supported permissions.
      */
     private List<String> requires;
+
+    /**
+     * The URL of a web-based management user interface for the service instance. Can be <code>null</code> to indicate
+     * that a management dashboard is not provided.
+     */
+    private String dashboardUrl;
 
     public Service() {
     }

--- a/src/main/java/com/orange/servicebroker/staticcreds/domain/ServicePlanDetail.java
+++ b/src/main/java/com/orange/servicebroker/staticcreds/domain/ServicePlanDetail.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 @ToString
 @EqualsAndHashCode
 @Builder
-public class PlanSummary {
+public class ServicePlanDetail {
 
     /**
      * The URL to which Cloud Foundry should drain logs for the bound application.
@@ -39,5 +39,10 @@ public class PlanSummary {
      */
     @Singular
     private Map<String, Object> credentials;
+
+    /**
+     * The URL of a web-based management user interface for the service instance.
+     */
+    private Optional<String> dashboardUrl;
 
 }

--- a/src/main/java/com/orange/servicebroker/staticcreds/domain/ServicePlanDetailRepository.java
+++ b/src/main/java/com/orange/servicebroker/staticcreds/domain/ServicePlanDetailRepository.java
@@ -5,8 +5,8 @@ import java.util.Optional;
 /**
  * Created by YSBU7453 on 04/04/2016.
  */
-public interface PlanSummaryRepository {
+public interface ServicePlanDetailRepository {
 
-    Optional<PlanSummary> find(String servicePlanId);
+    Optional<ServicePlanDetail> find(String servicePlanId);
 
 }

--- a/src/main/java/com/orange/servicebroker/staticcreds/infrastructure/SpringConfigServicePlanDetailRepository.java
+++ b/src/main/java/com/orange/servicebroker/staticcreds/infrastructure/SpringConfigServicePlanDetailRepository.java
@@ -10,31 +10,31 @@ import java.util.Optional;
  * Created by YSBU7453 on 03/05/2016.
  */
 @Component
-public class SpringConfigPlanSummaryRepository implements PlanSummaryRepository {
+public class SpringConfigServicePlanDetailRepository implements ServicePlanDetailRepository {
 
     private final CatalogSettings catalog;
 
     @Autowired
-    public SpringConfigPlanSummaryRepository(CatalogSettings catalogSettings) {
+    public SpringConfigServicePlanDetailRepository(CatalogSettings catalogSettings) {
         this.catalog = catalogSettings;
     }
 
 
     @Override
-    public Optional<PlanSummary> find(String servicePlanId) {
+    public Optional<ServicePlanDetail> find(String servicePlanId) {
         return catalog.getServices().values()
                 .stream()
                 .flatMap(service -> service.getPlans().values().stream()
                         .filter(plan -> servicePlanId.equals(plan.getId()))
-                        .map(plan -> toPlanSummary(service, plan))
+                        .map(plan -> toServicePlanDetail(service, plan))
                 )
                 .findFirst();
     }
 
-    private PlanSummary toPlanSummary(Service service, Plan plan) {
-        final PlanSummary.PlanSummaryBuilder builder = PlanSummary.builder();
-
-        builder.syslogDrainUrl(plan.getSyslogDrainUrl() != null ? Optional.of(plan.getSyslogDrainUrl()) : Optional.ofNullable(service.getSyslogDrainUrl()));
+    private ServicePlanDetail toServicePlanDetail(Service service, Plan plan) {
+        final ServicePlanDetail.ServicePlanDetailBuilder builder = ServicePlanDetail.builder();
+        builder.syslogDrainUrl(Optional.ofNullable(plan.getSyslogDrainUrl()).map(Optional::of).orElse(Optional.ofNullable(service.getSyslogDrainUrl())));
+        builder.dashboardUrl(Optional.ofNullable(plan.getDashboardUrl()).map(Optional::of).orElse(Optional.ofNullable(service.getDashboardUrl())));
         service.getFullCredentials().map(builder::credentials);
         plan.getFullCredentials().forEach(builder::credential);
 

--- a/src/main/java/com/orange/servicebroker/staticcreds/service/CredsServiceInstanceBindingService.java
+++ b/src/main/java/com/orange/servicebroker/staticcreds/service/CredsServiceInstanceBindingService.java
@@ -1,7 +1,7 @@
 package com.orange.servicebroker.staticcreds.service;
 
-import com.orange.servicebroker.staticcreds.domain.PlanSummary;
-import com.orange.servicebroker.staticcreds.domain.PlanSummaryRepository;
+import com.orange.servicebroker.staticcreds.domain.ServicePlanDetail;
+import com.orange.servicebroker.staticcreds.domain.ServicePlanDetailRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,23 +19,23 @@ public class CredsServiceInstanceBindingService implements ServiceInstanceBindin
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CredsServiceInstanceService.class);
 
-    private PlanSummaryRepository planSummaryRepository;
+    private ServicePlanDetailRepository servicePlanDetailRepository;
 
     @Autowired
-    public CredsServiceInstanceBindingService(PlanSummaryRepository planSummaryRepository) {
-        this.planSummaryRepository = planSummaryRepository;
+    public CredsServiceInstanceBindingService(ServicePlanDetailRepository servicePlanDetailRepository) {
+        this.servicePlanDetailRepository = servicePlanDetailRepository;
     }
 
-    private static CreateServiceInstanceBindingResponse toResponse(PlanSummary planSummary) {
+    private static CreateServiceInstanceBindingResponse toResponse(ServicePlanDetail servicePlanDetail) {
         return new CreateServiceInstanceAppBindingResponse()
-                .withCredentials(planSummary.getCredentials())
-                .withSyslogDrainUrl(planSummary.getSyslogDrainUrl().orElse(null));
+                .withCredentials(servicePlanDetail.getCredentials())
+                .withSyslogDrainUrl(servicePlanDetail.getSyslogDrainUrl().orElse(null));
     }
 
     @Override
     public CreateServiceInstanceBindingResponse createServiceInstanceBinding(CreateServiceInstanceBindingRequest request) {
         LOGGER.debug("binding service instance");
-        final Optional<PlanSummary> planSummary = planSummaryRepository.find(request.getPlanId());
+        final Optional<ServicePlanDetail> planSummary = servicePlanDetailRepository.find(request.getPlanId());
         return planSummary
                 .map(CredsServiceInstanceBindingService::toResponse)
                 .orElse(new CreateServiceInstanceAppBindingResponse());

--- a/src/main/java/com/orange/servicebroker/staticcreds/service/CredsServiceInstanceService.java
+++ b/src/main/java/com/orange/servicebroker/staticcreds/service/CredsServiceInstanceService.java
@@ -1,5 +1,7 @@
 package com.orange.servicebroker.staticcreds.service;
 
+import com.orange.servicebroker.staticcreds.domain.ServicePlanDetail;
+import com.orange.servicebroker.staticcreds.domain.ServicePlanDetailRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cloud.servicebroker.model.*;
@@ -9,19 +11,32 @@ import org.springframework.stereotype.Service;
 @Service
 public class CredsServiceInstanceService implements ServiceInstanceService {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(CredsServiceInstanceService.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(CredsServiceInstanceService.class);
 
-	@Override
-	public CreateServiceInstanceResponse createServiceInstance(CreateServiceInstanceRequest arg0) {
-		LOGGER.debug("creating service instance");
-		return new CreateServiceInstanceResponse();
-	}
+    private final ServicePlanDetailRepository repository;
 
-	@Override
-	public DeleteServiceInstanceResponse deleteServiceInstance(DeleteServiceInstanceRequest arg0) {
-		LOGGER.debug("deleting service instance");
-		return new DeleteServiceInstanceResponse();
-	}
+    public CredsServiceInstanceService(ServicePlanDetailRepository repository) {
+        this.repository = repository;
+    }
+
+    private static CreateServiceInstanceResponse toResponse(ServicePlanDetail servicePlanDetail) {
+        return new CreateServiceInstanceResponse()
+                .withDashboardUrl(servicePlanDetail.getDashboardUrl().orElse(null));
+    }
+
+    @Override
+    public CreateServiceInstanceResponse createServiceInstance(CreateServiceInstanceRequest request) {
+        LOGGER.debug("creating service instance");
+        return repository.find(request.getPlanId())
+                .map(CredsServiceInstanceService::toResponse)
+                .orElse(new CreateServiceInstanceResponse());
+    }
+
+    @Override
+    public DeleteServiceInstanceResponse deleteServiceInstance(DeleteServiceInstanceRequest request) {
+        LOGGER.debug("deleting service instance");
+        return new DeleteServiceInstanceResponse();
+    }
 
     @Override
     public GetLastServiceOperationResponse getLastOperation(GetLastServiceOperationRequest arg0) {
@@ -29,10 +44,9 @@ public class CredsServiceInstanceService implements ServiceInstanceService {
         return new GetLastServiceOperationResponse().withOperationState(OperationState.SUCCEEDED);
     }
 
-	@Override
-	public UpdateServiceInstanceResponse updateServiceInstance(UpdateServiceInstanceRequest arg0) {
-		LOGGER.debug("updating service instance");
-		return new UpdateServiceInstanceResponse();
-	}
-
+    @Override
+    public UpdateServiceInstanceResponse updateServiceInstance(UpdateServiceInstanceRequest arg0) {
+        LOGGER.debug("updating service instance");
+        return new UpdateServiceInstanceResponse();
+    }
 }

--- a/src/test/java/com/orange/RemoteConfigTest.java
+++ b/src/test/java/com/orange/RemoteConfigTest.java
@@ -1,20 +1,16 @@
 package com.orange;
 
-import com.orange.servicebroker.staticcreds.domain.PlanSummary;
-import com.orange.servicebroker.staticcreds.domain.PlanSummaryRepository;
+import com.orange.servicebroker.staticcreds.domain.ServicePlanDetail;
+import com.orange.servicebroker.staticcreds.domain.ServicePlanDetailRepository;
 import org.fest.assertions.Assertions;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.SpringApplicationConfiguration;
-import org.springframework.boot.test.WebIntegrationTest;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.servicebroker.model.Catalog;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import java.util.Map;
 import java.util.Optional;
 
 import static org.fest.assertions.Assertions.assertThat;
@@ -34,7 +30,7 @@ public class RemoteConfigTest {
     String serviceApiDirectoryName;
 
     @Autowired
-    PlanSummaryRepository planSummaryRepository;
+    ServicePlanDetailRepository servicePlanDetailRepository;
 
     @Autowired
     Catalog catalog;
@@ -49,7 +45,7 @@ public class RemoteConfigTest {
 
         //service plan id for plan dev of service API_DIRECTORY, see static-creds-broker.yml
 
-       final Optional<PlanSummary> credentials = planSummaryRepository.find(API_DIRECTORY_SERVICE_PLAN_DEV_ID);
+       final Optional<ServicePlanDetail> credentials = servicePlanDetailRepository.find(API_DIRECTORY_SERVICE_PLAN_DEV_ID);
 
         assertThat(credentials.get().getCredentials()).hasSize(3).includes(entry("HOSTNAME", "http://company.com"),entry("URI", "http://mydev-api.org"), entry("ACCESS_KEY", "devAZERT23456664DFDSFSDFDSF"));
 

--- a/src/test/java/com/orange/servicebroker/staticcreds/domain/ConfigureSyslogDrainUrlStage.java
+++ b/src/test/java/com/orange/servicebroker/staticcreds/domain/ConfigureSyslogDrainUrlStage.java
@@ -15,7 +15,7 @@
 
 package com.orange.servicebroker.staticcreds.domain;
 
-import com.orange.servicebroker.staticcreds.YAML;
+import com.orange.servicebroker.staticcreds.stories.formatter.CatalogYAML;
 import com.tngtech.jgiven.Stage;
 import org.assertj.core.api.Assertions;
 
@@ -26,7 +26,7 @@ public class ConfigureSyslogDrainUrlStage extends Stage<ConfigureSyslogDrainUrlS
 
     private CatalogSettings.InvalidSyslogDrainUrlException invalidSyslogDrainUrlException;
 
-    public ConfigureSyslogDrainUrlStage paas_ops_configures_catalog(@YAML CatalogSettings catalogSettings) {
+    public ConfigureSyslogDrainUrlStage paas_ops_configures_catalog(@CatalogYAML CatalogSettings catalogSettings) {
         try {
             catalogSettings.init();
         } catch (CatalogSettings.InvalidSyslogDrainUrlException e) {

--- a/src/test/java/com/orange/servicebroker/staticcreds/domain/ConfigureSyslogDrainUrlTest.java
+++ b/src/test/java/com/orange/servicebroker/staticcreds/domain/ConfigureSyslogDrainUrlTest.java
@@ -15,7 +15,7 @@
 
 package com.orange.servicebroker.staticcreds.domain;
 
-import com.orange.servicebroker.staticcreds.ConfigureCatalog;
+import com.orange.servicebroker.staticcreds.stories.tags.ConfigureCatalog;
 import com.tngtech.jgiven.junit.SimpleScenarioTest;
 import org.junit.Test;
 

--- a/src/test/java/com/orange/servicebroker/staticcreds/infrastructure/SpringConfigCredentialsRepositoryTest.java
+++ b/src/test/java/com/orange/servicebroker/staticcreds/infrastructure/SpringConfigCredentialsRepositoryTest.java
@@ -1,9 +1,8 @@
 package com.orange.servicebroker.staticcreds.infrastructure;
 
-import com.orange.servicebroker.staticcreds.domain.PlanSummary;
+import com.orange.servicebroker.staticcreds.domain.ServicePlanDetail;
 import org.junit.Test;
 
-import java.util.Map;
 import java.util.Optional;
 
 import static com.orange.servicebroker.staticcreds.infrastructure.CatalogTestFactory.HOSTNAME_PLAN_PROD_VALUE;
@@ -21,9 +20,9 @@ public class SpringConfigCredentialsRepositoryTest {
 
         //GIVEN credentials have been set at service and plan level
         //some overlaps
-        SpringConfigPlanSummaryRepository repository = new SpringConfigPlanSummaryRepository(CatalogTestFactory.newInstance());
+        SpringConfigServicePlanDetailRepository repository = new SpringConfigServicePlanDetailRepository(CatalogTestFactory.newInstance());
 
-        final Optional<PlanSummary> planSummary = repository.find(CatalogTestFactory.SERVICE_PLAN_PROD);
+        final Optional<ServicePlanDetail> planSummary = repository.find(CatalogTestFactory.SERVICE_PLAN_PROD);
 
         assertThat(planSummary.get().getCredentials()).hasSize(3).includes(entry("HOSTNAME", HOSTNAME_PLAN_PROD_VALUE),entry("URI", "http://myprod-api.org"), entry("ACCESS_KEY", "prod"));
 

--- a/src/test/java/com/orange/servicebroker/staticcreds/service/CreateLogDrainServiceBindingStage.java
+++ b/src/test/java/com/orange/servicebroker/staticcreds/service/CreateLogDrainServiceBindingStage.java
@@ -15,10 +15,10 @@
 
 package com.orange.servicebroker.staticcreds.service;
 
-import com.orange.servicebroker.staticcreds.JSON;
-import com.orange.servicebroker.staticcreds.YAML;
 import com.orange.servicebroker.staticcreds.domain.CatalogSettings;
-import com.orange.servicebroker.staticcreds.infrastructure.SpringConfigPlanSummaryRepository;
+import com.orange.servicebroker.staticcreds.infrastructure.SpringConfigServicePlanDetailRepository;
+import com.orange.servicebroker.staticcreds.stories.formatter.CatalogYAML;
+import com.orange.servicebroker.staticcreds.stories.formatter.CreateServiceBindingResponseJSON;
 import com.tngtech.jgiven.Stage;
 import org.assertj.core.api.Assertions;
 import org.springframework.cloud.servicebroker.model.CreateServiceInstanceAppBindingResponse;
@@ -39,20 +39,13 @@ public class CreateLogDrainServiceBindingStage extends Stage<CreateLogDrainServi
         return self();
     }
 
-    public CreateLogDrainServiceBindingStage syslog_drain_url_set_in_catalog(@YAML CatalogSettings catalog) {
-        SpringConfigPlanSummaryRepository planSummaryRepository = new SpringConfigPlanSummaryRepository(catalog);
+    public CreateLogDrainServiceBindingStage syslog_drain_url_set_in_catalog(@CatalogYAML CatalogSettings catalog) {
+        SpringConfigServicePlanDetailRepository planSummaryRepository = new SpringConfigServicePlanDetailRepository(catalog);
         instanceBindingService = new CredsServiceInstanceBindingService(planSummaryRepository);
         return self();
     }
 
-
-    public CreateLogDrainServiceBindingStage it_should_be_returned_with_syslog_drain_url(String syslogDrainUrl) {
-        Assertions.assertThat(response).isInstanceOf(CreateServiceInstanceAppBindingResponse.class);
-        Assertions.assertThat(((CreateServiceInstanceAppBindingResponse) response).getSyslogDrainUrl()).isEqualTo(syslogDrainUrl);
-        return self();
-    }
-
-    public CreateLogDrainServiceBindingStage it_should_be_returned_with_syslog_drain_url(@JSON CreateServiceInstanceAppBindingResponse expected) {
+    public CreateLogDrainServiceBindingStage it_should_be_returned_with_syslog_drain_url(@CreateServiceBindingResponseJSON CreateServiceInstanceAppBindingResponse expected) {
         Assertions.assertThat(response).isInstanceOf(CreateServiceInstanceAppBindingResponse.class);
         Assertions.assertThat(response).isEqualTo(expected);
         return self();

--- a/src/test/java/com/orange/servicebroker/staticcreds/service/CreateLogDrainServiceBindingTest.java
+++ b/src/test/java/com/orange/servicebroker/staticcreds/service/CreateLogDrainServiceBindingTest.java
@@ -15,10 +15,10 @@
 
 package com.orange.servicebroker.staticcreds.service;
 
-import com.orange.servicebroker.staticcreds.CreateServiceBinding;
 import com.orange.servicebroker.staticcreds.domain.CatalogSettings;
 import com.orange.servicebroker.staticcreds.domain.Plan;
 import com.orange.servicebroker.staticcreds.domain.Service;
+import com.orange.servicebroker.staticcreds.stories.tags.CreateServiceBinding;
 import com.tngtech.jgiven.junit.SimpleScenarioTest;
 import org.junit.Test;
 import org.springframework.cloud.servicebroker.model.CreateServiceInstanceAppBindingResponse;
@@ -83,8 +83,6 @@ public class CreateLogDrainServiceBindingTest extends SimpleScenarioTest<CreateL
     public void create_service_binding_with_static_syslog_drain_url_set_at_service_level() throws Exception {
         given().syslog_drain_url_set_in_catalog(catalog_syslog_drain_url_at_service_level_with_requires_field_set());
         when().cloud_controller_requests_to_create_a_service_instance_binding_for_plan_id("dev-id");
-        Map<String, Object> credentials = new HashMap<>();
-        credentials.put("URI", "http://my-api.org");
         then().it_should_be_returned_with_syslog_drain_url(new CreateServiceInstanceAppBindingResponse()
                 .withSyslogDrainUrl("syslog://log.example.com:5000")
                 .withCredentials(Collections.unmodifiableMap(Stream.of(
@@ -96,8 +94,6 @@ public class CreateLogDrainServiceBindingTest extends SimpleScenarioTest<CreateL
     public void create_service_binding_with_static_syslog_drain_url_set_at_service_plan_level() throws Exception {
         given().syslog_drain_url_set_in_catalog(catalog_syslog_drain_url_at_service_plan_level_with_requires_field_set());
         when().cloud_controller_requests_to_create_a_service_instance_binding_for_plan_id("dev-id");
-        Map<String, Object> credentials = new HashMap<>();
-        credentials.put("URI", "http://my-api.org");
         then().it_should_be_returned_with_syslog_drain_url(new CreateServiceInstanceAppBindingResponse()
                 .withSyslogDrainUrl("syslog://log.dev.com:5000")
                 .withCredentials(Collections.unmodifiableMap(Stream.of(

--- a/src/test/java/com/orange/servicebroker/staticcreds/service/CredsServiceInstanceBindingServiceTest.java
+++ b/src/test/java/com/orange/servicebroker/staticcreds/service/CredsServiceInstanceBindingServiceTest.java
@@ -18,7 +18,7 @@ package com.orange.servicebroker.staticcreds.service;
 import com.orange.servicebroker.staticcreds.domain.CatalogSettings;
 import com.orange.servicebroker.staticcreds.domain.Plan;
 import com.orange.servicebroker.staticcreds.domain.Service;
-import com.orange.servicebroker.staticcreds.infrastructure.SpringConfigPlanSummaryRepository;
+import com.orange.servicebroker.staticcreds.infrastructure.SpringConfigServicePlanDetailRepository;
 import org.junit.Test;
 import org.springframework.cloud.servicebroker.model.CreateServiceInstanceAppBindingResponse;
 import org.springframework.cloud.servicebroker.model.CreateServiceInstanceBindingRequest;
@@ -44,7 +44,7 @@ public class CredsServiceInstanceBindingServiceTest {
     @Test
     public void should_bind_with_credentials_that_have_been_set_for_associated_service_plan() throws Exception {
 
-        SpringConfigPlanSummaryRepository repository = new SpringConfigPlanSummaryRepository(catalog());
+        SpringConfigServicePlanDetailRepository repository = new SpringConfigServicePlanDetailRepository(catalog());
 
         //when I bind my app to a service API_DIRECTORY instance whose plan is dev
         CredsServiceInstanceBindingService serviceInstanceBindingService = new CredsServiceInstanceBindingService(repository);
@@ -83,7 +83,7 @@ public class CredsServiceInstanceBindingServiceTest {
 
     @Test
     public void should_bind_with_no_credentials_if_no_credentials_have_been_set_for_associated_service_plan() throws Exception {
-        SpringConfigPlanSummaryRepository repository = new SpringConfigPlanSummaryRepository(catalog());
+        SpringConfigServicePlanDetailRepository repository = new SpringConfigServicePlanDetailRepository(catalog());
 
         //when I bind my app to a service API_DIRECTORY instance whose plan is dummy
         CredsServiceInstanceBindingService serviceInstanceBindingService = new CredsServiceInstanceBindingService(repository);

--- a/src/test/java/com/orange/servicebroker/staticcreds/stories/create_service_instance/CreateServiceInstanceInstanceWithDashboardUrlTest.java
+++ b/src/test/java/com/orange/servicebroker/staticcreds/stories/create_service_instance/CreateServiceInstanceInstanceWithDashboardUrlTest.java
@@ -1,0 +1,95 @@
+/*
+ * *
+ *  * Copyright (C) 2015 Orange
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.orange.servicebroker.staticcreds.stories.create_service_instance;
+
+import com.orange.servicebroker.staticcreds.domain.CatalogSettings;
+import com.orange.servicebroker.staticcreds.domain.Plan;
+import com.orange.servicebroker.staticcreds.domain.Service;
+import com.orange.servicebroker.staticcreds.stories.tags.CreateServiceInstance;
+import com.tngtech.jgiven.junit.SimpleScenarioTest;
+import org.junit.Test;
+import org.springframework.cloud.servicebroker.model.CreateServiceInstanceResponse;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Sebastien Bortolussi
+ */
+@CreateServiceInstance
+public class CreateServiceInstanceInstanceWithDashboardUrlTest extends SimpleScenarioTest<CreateServiceInstanceStage> {
+
+    private static CatalogSettings apply_dashboard_url_for_all_plans_of_a_service() {
+        Plan dev = new Plan("dev");
+        dev.setId("dev-id");
+        Map<String, Object> credentials = new HashMap<>();
+        credentials.put("URI", "http://my-api.org");
+        dev.setCredentials(credentials);
+
+        Service myService = new Service();
+        myService.setName("myservice");
+        myService.setId("myservice-id");
+        myService.setDashboardUrl("http://example-dashboard.example.com/9189kdfsk0vfnku");
+        final Map<String, Plan> myServicePlans = new HashMap<>();
+        myServicePlans.put("dev", dev);
+        myService.setPlans(myServicePlans);
+
+        final Map<String, Service> services = new HashMap<>();
+        services.put("myservice", myService);
+
+        return new CatalogSettings(services);
+    }
+
+    private static CatalogSettings apply_dashboard_url_for_a_service_plan() {
+        Plan dev = new Plan("dev");
+        dev.setId("dev-id");
+        Map<String, Object> credentials = new HashMap<>();
+        credentials.put("URI", "http://my-api.org");
+        dev.setCredentials(credentials);
+        dev.setDashboardUrl("http://example-dashboard.dev.com/9189kdfsk0vfnku");
+
+
+        Service myService = new Service();
+        myService.setName("myservice");
+        myService.setId("myservice-id");
+        final Map<String, Plan> myServicePlans = new HashMap<>();
+        myServicePlans.put("dev", dev);
+        myService.setPlans(myServicePlans);
+
+        final Map<String, Service> services = new HashMap<>();
+        services.put("myservice", myService);
+
+        return new CatalogSettings(services);
+    }
+
+    @Test
+    public void create_service_instance_with_dashboard_url_set_for_all_plans_of_a_service() throws Exception {
+        given().catalog(apply_dashboard_url_for_all_plans_of_a_service());
+        when().cloud_controller_requests_to_create_a_service_instance_for_plan_id("dev-id");
+        then().it_should_be_returned_with_dashboard_url(new CreateServiceInstanceResponse()
+                .withDashboardUrl("http://example-dashboard.example.com/9189kdfsk0vfnku"));
+    }
+
+    @Test
+    public void create_service_instance_with_dashboard_url_set_for_a_service_plan() throws Exception {
+        given().catalog(apply_dashboard_url_for_a_service_plan());
+        when().cloud_controller_requests_to_create_a_service_instance_for_plan_id("dev-id");
+        then().it_should_be_returned_with_dashboard_url(new CreateServiceInstanceResponse()
+                .withDashboardUrl("http://example-dashboard.dev.com/9189kdfsk0vfnku"));
+    }
+
+
+}

--- a/src/test/java/com/orange/servicebroker/staticcreds/stories/create_service_instance/CreateServiceInstanceStage.java
+++ b/src/test/java/com/orange/servicebroker/staticcreds/stories/create_service_instance/CreateServiceInstanceStage.java
@@ -1,0 +1,55 @@
+/*
+ * *
+ *  * Copyright (C) 2015 Orange
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.orange.servicebroker.staticcreds.stories.create_service_instance;
+
+import com.orange.servicebroker.staticcreds.domain.CatalogSettings;
+import com.orange.servicebroker.staticcreds.infrastructure.SpringConfigServicePlanDetailRepository;
+import com.orange.servicebroker.staticcreds.service.CredsServiceInstanceService;
+import com.orange.servicebroker.staticcreds.stories.formatter.CatalogYAML;
+import com.orange.servicebroker.staticcreds.stories.formatter.CreateServiceInstanceResponseJSON;
+import com.tngtech.jgiven.Stage;
+import org.assertj.core.api.Assertions;
+import org.springframework.cloud.servicebroker.model.CreateServiceInstanceRequest;
+import org.springframework.cloud.servicebroker.model.CreateServiceInstanceResponse;
+
+/**
+ * @author Sebastien Bortolussi
+ */
+public class CreateServiceInstanceStage extends Stage<CreateServiceInstanceStage> {
+
+    private CredsServiceInstanceService instanceService;
+    private CreateServiceInstanceResponse response;
+
+    public CreateServiceInstanceStage catalog(@CatalogYAML CatalogSettings catalog) {
+        SpringConfigServicePlanDetailRepository planSummaryRepository = new SpringConfigServicePlanDetailRepository(catalog);
+        instanceService = new CredsServiceInstanceService(planSummaryRepository);
+        return self();
+    }
+
+
+    public CreateServiceInstanceStage cloud_controller_requests_to_create_a_service_instance_for_plan_id(String servicePlanId) {
+        final CreateServiceInstanceRequest request = new CreateServiceInstanceRequest("myservice-id", servicePlanId, "org-id", "space-id");
+        response = instanceService.createServiceInstance(request);
+        return self();
+    }
+
+    public CreateServiceInstanceStage it_should_be_returned_with_dashboard_url(@CreateServiceInstanceResponseJSON CreateServiceInstanceResponse expected) {
+        Assertions.assertThat(response).isEqualTo(expected);
+        return self();
+    }
+
+}
+

--- a/src/test/java/com/orange/servicebroker/staticcreds/stories/formatter/CatalogYAML.java
+++ b/src/test/java/com/orange/servicebroker/staticcreds/stories/formatter/CatalogYAML.java
@@ -1,0 +1,32 @@
+/*
+ * *
+ *  * Copyright (C) 2015 Orange
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.orange.servicebroker.staticcreds.stories.formatter;
+
+import com.tngtech.jgiven.annotation.Format;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Sebastien Bortolussi
+ */
+@Format( value = CatalogYAMLFormatter.class)
+@Retention( RetentionPolicy.RUNTIME )
+@Target( { ElementType.PARAMETER, ElementType.ANNOTATION_TYPE } )
+public @interface CatalogYAML {
+}

--- a/src/test/java/com/orange/servicebroker/staticcreds/stories/formatter/CatalogYAMLFormatter.java
+++ b/src/test/java/com/orange/servicebroker/staticcreds/stories/formatter/CatalogYAMLFormatter.java
@@ -13,7 +13,7 @@
  *
  */
 
-package com.orange.servicebroker.staticcreds;
+package com.orange.servicebroker.staticcreds.stories.formatter;
 
 import com.orange.servicebroker.staticcreds.domain.CatalogSettings;
 import com.tngtech.jgiven.format.ArgumentFormatter;

--- a/src/test/java/com/orange/servicebroker/staticcreds/stories/formatter/CreateServiceBindingResponseFormatter.java
+++ b/src/test/java/com/orange/servicebroker/staticcreds/stories/formatter/CreateServiceBindingResponseFormatter.java
@@ -13,7 +13,7 @@
  *
  */
 
-package com.orange.servicebroker.staticcreds.service;
+package com.orange.servicebroker.staticcreds.stories.formatter;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/test/java/com/orange/servicebroker/staticcreds/stories/formatter/CreateServiceBindingResponseJSON.java
+++ b/src/test/java/com/orange/servicebroker/staticcreds/stories/formatter/CreateServiceBindingResponseJSON.java
@@ -13,10 +13,8 @@
  *
  */
 
-package com.orange.servicebroker.staticcreds;
+package com.orange.servicebroker.staticcreds.stories.formatter;
 
-import com.orange.servicebroker.staticcreds.CatalogYAMLFormatter;
-import com.orange.servicebroker.staticcreds.service.CreateServiceBindingResponseFormatter;
 import com.tngtech.jgiven.annotation.Format;
 
 import java.lang.annotation.ElementType;
@@ -30,4 +28,5 @@ import java.lang.annotation.Target;
 @Format( value = CreateServiceBindingResponseFormatter.class)
 @Retention( RetentionPolicy.RUNTIME )
 @Target( { ElementType.PARAMETER, ElementType.ANNOTATION_TYPE } )
-public @interface JSON {}
+public @interface CreateServiceBindingResponseJSON {
+}

--- a/src/test/java/com/orange/servicebroker/staticcreds/stories/formatter/CreateServiceInstanceResponseFormatter.java
+++ b/src/test/java/com/orange/servicebroker/staticcreds/stories/formatter/CreateServiceInstanceResponseFormatter.java
@@ -1,0 +1,37 @@
+/*
+ * *
+ *  * Copyright (C) 2015 Orange
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.orange.servicebroker.staticcreds.stories.formatter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tngtech.jgiven.format.ArgumentFormatter;
+import org.springframework.cloud.servicebroker.model.CreateServiceInstanceResponse;
+
+/**
+ * General formatter to format catalog values to yaml.
+ */
+public class CreateServiceInstanceResponseFormatter implements ArgumentFormatter<CreateServiceInstanceResponse> {
+
+    @Override
+    public String format(CreateServiceInstanceResponse response, String... strings) {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            return mapper.writer().withDefaultPrettyPrinter().writeValueAsString(response);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/orange/servicebroker/staticcreds/stories/formatter/CreateServiceInstanceResponseJSON.java
+++ b/src/test/java/com/orange/servicebroker/staticcreds/stories/formatter/CreateServiceInstanceResponseJSON.java
@@ -13,18 +13,20 @@
  *
  */
 
-package com.orange.servicebroker.staticcreds;
+package com.orange.servicebroker.staticcreds.stories.formatter;
 
-import com.tngtech.jgiven.annotation.IsTag;
+import com.tngtech.jgiven.annotation.Format;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-@IsTag(name = "Paas user requests to create a service binding",
-        description = "In order to access a service resource,<br>" +
-                "As a Paas user,<br>" +
-                "I want to get the necessary credentials on service binding.")
+/**
+ * @author Sebastien Bortolussi
+ */
+@Format(value = CreateServiceInstanceResponseFormatter.class)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface CreateServiceBinding {
-
+@Target({ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+public @interface CreateServiceInstanceResponseJSON {
 }

--- a/src/test/java/com/orange/servicebroker/staticcreds/stories/tags/ConfigureCatalog.java
+++ b/src/test/java/com/orange/servicebroker/staticcreds/stories/tags/ConfigureCatalog.java
@@ -13,7 +13,7 @@
  *
  */
 
-package com.orange.servicebroker.staticcreds;
+package com.orange.servicebroker.staticcreds.stories.tags;
 
 import com.tngtech.jgiven.annotation.IsTag;
 

--- a/src/test/java/com/orange/servicebroker/staticcreds/stories/tags/CreateServiceBinding.java
+++ b/src/test/java/com/orange/servicebroker/staticcreds/stories/tags/CreateServiceBinding.java
@@ -13,19 +13,18 @@
  *
  */
 
-package com.orange.servicebroker.staticcreds;
+package com.orange.servicebroker.staticcreds.stories.tags;
 
-import com.tngtech.jgiven.annotation.Format;
+import com.tngtech.jgiven.annotation.IsTag;
 
-import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
 
-/**
- * @author Sebastien Bortolussi
- */
-@Format( value = CatalogYAMLFormatter.class)
-@Retention( RetentionPolicy.RUNTIME )
-@Target( { ElementType.PARAMETER, ElementType.ANNOTATION_TYPE } )
-public @interface YAML {}
+@IsTag(name = "Paas user requests to create a service binding",
+        description = "In order to access to an external resource,<br>" +
+                "As a Paas user,<br>" +
+                "I want to create a service instance binding and get the necessary details for accessing the external resource.")
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CreateServiceBinding {
+
+}

--- a/src/test/java/com/orange/servicebroker/staticcreds/stories/tags/CreateServiceInstance.java
+++ b/src/test/java/com/orange/servicebroker/staticcreds/stories/tags/CreateServiceInstance.java
@@ -1,0 +1,30 @@
+/*
+ * *
+ *  * Copyright (C) 2015 Orange
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.orange.servicebroker.staticcreds.stories.tags;
+
+import com.tngtech.jgiven.annotation.IsTag;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@IsTag(name = "Paas user requests to create a service instance",
+        description = "In order to provision an external resource,<br>" +
+                "As a Paas user,<br>" +
+                "I want to create a service instance and get details for it.")
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CreateServiceInstance {
+
+}


### PR DESCRIPTION
These changes add support for dashboard_url. Static cred broker may return, in the create instance response, a dashboard_url of a web-based management user interface for the service instance .

[#29]